### PR TITLE
[Feat] Level 7 구현 

### DIFF
--- a/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Application/SceneDelegate.swift
+++ b/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Application/SceneDelegate.swift
@@ -18,7 +18,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = scene as? UIWindowScene else { return }
         window = UIWindow(windowScene: windowScene)
         let vc = ExchangeRateViewController(
-            viewModel: ExchangeRateViewModel(networkService: NetworkService())
+            viewModel: ExchangeRateViewModel(
+                networkService: NetworkService(),
+                currencyCodeStorage: CurrencyCodeStorage()
+            )
         )
         window?.rootViewController = UINavigationController(rootViewController: vc)
         window?.makeKeyAndVisible()

--- a/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Data/Network/DTO/ExchangeRateDTO.swift
+++ b/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Data/Network/DTO/ExchangeRateDTO.swift
@@ -17,6 +17,7 @@ extension ExchangeRateDTO {
             let nation = ExchangeRateDTO.mapping[code] ?? "알 수 없음"
             return ExchangeRate(currencyCode: code, rate: rate, nation: nation)
         }
+        .sorted { $0.currencyCode < $1.currencyCode }
     }
     
     static let mapping = [

--- a/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Data/Repository/CoreDataStorage/CoreDataStorage.swift
+++ b/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Data/Repository/CoreDataStorage/CoreDataStorage.swift
@@ -1,0 +1,37 @@
+//
+//  CoreDataStorage.swift
+//  ExchangeRateCalculation
+//
+//  Created by 최안용 on 4/18/25.
+//
+
+import CoreData
+import UIKit
+
+final class CoreDataStorage {
+    static let shared = CoreDataStorage()
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "CoreDataStorage")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+    
+    // MARK: - Core Data Saving support
+    
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
+}

--- a/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Data/Repository/CoreDataStorage/CoreDataStorage.xcdatamodeld/CoreDataStorage.xcdatamodel/contents
+++ b/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Data/Repository/CoreDataStorage/CoreDataStorage.xcdatamodeld/CoreDataStorage.xcdatamodel/contents
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="24A348" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="CurrencyCode" representedClassName="CurrencyCode" syncable="YES">
+        <attribute name="code" optional="YES" attributeType="String"/>
+    </entity>
+</model>

--- a/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Data/Repository/CoreDataStorage/CurrencyCodeStorage/CurrencyCode+CoreDataClass.swift
+++ b/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Data/Repository/CoreDataStorage/CurrencyCodeStorage/CurrencyCode+CoreDataClass.swift
@@ -1,0 +1,18 @@
+//
+//  CurrencyCode+CoreDataClass.swift
+//  ExchangeRateCalculation
+//
+//  Created by 최안용 on 4/18/25.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(ExchangeRate)
+public class CurrencyCode: NSManagedObject {
+    public static let entityName: String = "CurrencyCode"
+    public enum Key {
+        static let code = "code"
+    }
+}

--- a/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Data/Repository/CoreDataStorage/CurrencyCodeStorage/CurrencyCode+CoreDataProperties.swift
+++ b/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Data/Repository/CoreDataStorage/CurrencyCodeStorage/CurrencyCode+CoreDataProperties.swift
@@ -1,0 +1,23 @@
+//
+//  CurrencyCode+CoreDataProperties.swift
+//  ExchangeRateCalculation
+//
+//  Created by 최안용 on 4/18/25.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension CurrencyCode {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<CurrencyCode> {
+        return NSFetchRequest<CurrencyCode>(entityName: CurrencyCode.entityName)
+    }
+
+    @NSManaged public var Code: String?
+}
+
+extension CurrencyCode : Identifiable {
+
+}

--- a/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Data/Repository/CoreDataStorage/CurrencyCodeStorage/CurrencyCodeStorage.swift
+++ b/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Data/Repository/CoreDataStorage/CurrencyCodeStorage/CurrencyCodeStorage.swift
@@ -1,0 +1,82 @@
+//
+//  CurrencyCodeStorage.swift
+//  ExchangeRateCalculation
+//
+//  Created by 최안용 on 4/18/25.
+//
+
+import CoreData
+import Foundation
+
+protocol CurrencyCodeStorageProtocol {
+    func getCodeAll() -> [String]
+    func saveCode(_ code: String)
+    func removeCode(_ code: String)
+}
+
+final class CurrencyCodeStorage: CurrencyCodeStorageProtocol {
+    private let coreDataStorage = CoreDataStorage.shared
+    
+    func getCodeAll() -> [String] {
+        do {
+            var currencyCodes: [String] = []
+            
+            let codes = try self.coreDataStorage.persistentContainer.viewContext.fetch(
+                CurrencyCode.fetchRequest()
+            )
+            
+            for code in codes as [NSManagedObject] {
+                if let code = code.value(forKey: CurrencyCode.Key.code) as? String {
+                    currencyCodes.append(code)
+                }
+            }
+            
+            return currencyCodes
+        } catch {
+            print("데이터 읽기 실패")
+            return []
+        }
+    }
+    
+    func saveCode(_ code: String) {
+        guard let entity = NSEntityDescription.entity(
+            forEntityName: CurrencyCode.entityName,
+            in: coreDataStorage.persistentContainer.viewContext
+        ) else {
+            return
+        }
+        
+        let newCurrecyCode = NSManagedObject(
+            entity: entity,
+            insertInto: coreDataStorage.persistentContainer.viewContext
+        )
+        
+        newCurrecyCode.setValue(code, forKey: CurrencyCode.Key.code)
+        
+        do {
+            try coreDataStorage.persistentContainer.viewContext.save()
+            print("저장 성공")
+        } catch {
+            print("저장 실패")
+        }
+    }
+    
+    func removeCode(_ code: String) {
+        let fetchRequest = CurrencyCode.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "\(CurrencyCode.Key.code) == %@", code)
+        
+        do {
+            let result = try coreDataStorage.persistentContainer.viewContext.fetch(fetchRequest)
+            
+            for data in result as [NSManagedObject] {
+                coreDataStorage.persistentContainer.viewContext.delete(data)
+                print("삭제된 데이터: \(data)")
+            }
+            
+            try coreDataStorage.persistentContainer.viewContext.save()
+            print("삭제 완료")
+        } catch {
+            print("삭제 실패")
+        }
+    }
+}

--- a/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Domain/Entities/ExchangeRate.swift
+++ b/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Domain/Entities/ExchangeRate.swift
@@ -11,4 +11,5 @@ struct ExchangeRate {
     let currencyCode: String
     let rate: Double
     let nation: String
+    var isSelected: Bool = false
 }

--- a/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Presentation/View/ExchangeRateScene/ExchangeRateViewController.swift
+++ b/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Presentation/View/ExchangeRateScene/ExchangeRateViewController.swift
@@ -108,8 +108,10 @@ extension ExchangeRateViewController: UITableViewDataSource {
         cell.configure(
             currencyCode: exchangeRate.currencyCode,
             nation: exchangeRate.nation,
-            rate: exchangeRate.rate
+            rate: exchangeRate.rate,
+            isSelected: exchangeRate.isSelected
         )
+        cell.delegate = self
         
         return cell
     }
@@ -119,5 +121,11 @@ extension ExchangeRateViewController: UITableViewDataSource {
 extension ExchangeRateViewController: UISearchBarDelegate {
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         viewModel.action?(.search(text: searchText))
+    }
+}
+
+extension ExchangeRateViewController: ExchangeRateCellDelegate {
+    func didTapStarButton(_ code: String, _ selected: Bool) {
+        viewModel.action?(.didTapStar(code: code, isSelected: selected))
     }
 }

--- a/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Presentation/View/ExchangeRateScene/View/ExchangeRateCell.swift
+++ b/anyong/ExchangeRateCalculation/ExchangeRateCalculation/Presentation/View/ExchangeRateScene/View/ExchangeRateCell.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol ExchangeRateCellDelegate: AnyObject {
+    func didTapStarButton(_ code: String, _ selected: Bool)
+}
+
 final class ExchangeRateCell: UITableViewCell {
     static let identifier = "ExchangeRateCell"
     
@@ -14,6 +18,9 @@ final class ExchangeRateCell: UITableViewCell {
     private let nationLabel = UILabel()
     private let labelStackView = UIStackView()
     private let rateLabel = UILabel()
+    private let starButton = UIButton()
+    
+    weak var delegate: ExchangeRateCellDelegate?
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -46,11 +53,18 @@ final class ExchangeRateCell: UITableViewCell {
             $0.font = .systemFont(ofSize: 16)
             $0.textAlignment = .right
         }
+        
+        starButton.do {
+            $0.setImage(.init(systemName: "star"), for: .normal)
+            $0.setImage(.init(systemName: "star.fill"), for: .selected)
+            $0.tintColor = .systemYellow            
+            $0.addTarget(self, action: #selector(didTapStarButton), for: .touchUpInside)
+        }
     }
     
     private func setUI() {
         labelStackView.addArrangedSubviews(currencyCodeLabel, nationLabel)
-        addsubViews(labelStackView, rateLabel)
+        contentView.addsubViews(labelStackView, rateLabel, starButton)
     }
     
     private func setLayout() {
@@ -60,18 +74,34 @@ final class ExchangeRateCell: UITableViewCell {
         }
         
         rateLabel.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(16)
             $0.centerY.equalToSuperview()
             $0.leading.greaterThanOrEqualTo(labelStackView.snp.trailing).offset(16)
             $0.width.equalTo(120)
         }
+        
+        starButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(rateLabel.snp.trailing).offset(15)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.size.equalTo(20)
+        }
+    }
+}
+
+extension ExchangeRateCell {    
+    func configure(currencyCode: String, nation: String, rate: Double, isSelected: Bool) {
+        currencyCodeLabel.text = currencyCode
+        nationLabel.text = nation
+        rateLabel.text = String(format: "%.4f", rate)
+        starButton.isSelected = isSelected
     }
 }
 
 extension ExchangeRateCell {
-    func configure(currencyCode: String, nation: String, rate: Double) {
-        currencyCodeLabel.text = currencyCode
-        nationLabel.text = nation
-        rateLabel.text = String(format: "%.4f", rate)
+    @objc
+    private func didTapStarButton() {
+        guard let code = currencyCodeLabel.text else { return }
+        starButton.isSelected.toggle()
+        delegate?.didTapStarButton(code, starButton.isSelected)
     }
 }


### PR DESCRIPTION
## Level 7  - 즐겨찾기 기능 상단 고정
- [x] 셀 우측에 ⭐ / ☆ 버튼 추가
- [x] 클릭 시 해당 통화 코드가 `CoreData`에 저장/삭제
- [x] 리스트 출력 시 즐겨찾기 데이터를 먼저 상단에 배치
- [x] 즐겨찾기된 데이터도 알파벳 오름차순 정렬
- [x] 즐겨찾기 상태에 따라 ⭐ / ☆ UI를 다르게 표시

## 시연영상
|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/3af563ab-e71a-44d8-bb14-394387de9c0a" width ="250"> | <img src = "https://github.com/user-attachments/assets/07bd608f-b771-4378-a56b-24a6aac9a683" width ="250"> |
