### PR TITLE
feat: Level 9, 10 구현

### DIFF
--- a/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Application/SceneDelegate.swift
+++ b/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Application/SceneDelegate.swift
@@ -17,10 +17,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         window = UIWindow(windowScene: windowScene)
         window?.backgroundColor = .systemBackground
-        let mockDateService = MockDataService() // 일부 통화가 저장되어 있는 목데이터
-        let dataService = DataService()
+        let viewModel = MainViewModel(service: DataService())
+//        let viewModel = MainViewModel(service: MockDataService()) // 일부 통화가 저장되어 있는 목데이터
         let mainNavigationController = UINavigationController(
-            rootViewController: MainViewController(viewModel: MainViewModel(service: mockDateService))
+            rootViewController: MainViewController(viewModel: viewModel)
         )
         window?.rootViewController = mainNavigationController
         window?.makeKeyAndVisible()

--- a/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Application/SceneDelegate.swift
+++ b/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Application/SceneDelegate.swift
@@ -17,6 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         window = UIWindow(windowScene: windowScene)
         window?.backgroundColor = .systemBackground
+
         let viewModel = MainViewModel(service: DataService())
 //        let viewModel = MainViewModel(service: MockDataService()) // 일부 통화가 저장되어 있는 목데이터
         let mainNavigationController = UINavigationController(
@@ -24,6 +25,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         )
         window?.rootViewController = mainNavigationController
         window?.makeKeyAndVisible()
+
+        if let lastPage = CoreDataStack.shared.fetchLastPage(),
+           let identifier = lastPage.identifier,
+           let params = lastPage.getParams() {
+            restoreLastState(identifier: identifier, params: params, navigationController: mainNavigationController)
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -33,15 +40,80 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
+        guard let windowScene = scene as? UIWindowScene,
+              let window = windowScene.windows.first,
+              let rootVC = window.rootViewController else { return }
+
+        if let currentVC = getCurrentViewController(from: rootVC) as? StateSavable {
+            let identifier = currentVC.identifier
+            let params = currentVC.getStateParams()
+            CoreDataStack.shared.saveLastPage(identifier: identifier, params: params)
+        }
+        CoreDataStack.shared.saveContext()
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
-        CoreDataStack.shared.saveContext()
+        guard let windowScene = scene as? UIWindowScene,
+              let window = windowScene.windows.first,
+              let rootVC = window.rootViewController else { return }
+
+        if let currentVC = getCurrentViewController(from: rootVC) as? StateSavable {
+            let identifier = currentVC.identifier
+            let params = currentVC.getStateParams()
+            CoreDataStack.shared.saveLastPage(identifier: identifier, params: params)
+        }
     }
 
+    private func getCurrentViewController(from rootVC: UIViewController) -> UIViewController {
+        if let tabBarController = rootVC as? UITabBarController,
+           let selectedVC = tabBarController.selectedViewController {
+            return getCurrentViewController(from: selectedVC)
+        }
 
+        if let navigationController = rootVC as? UINavigationController,
+           let visibleVC = navigationController.visibleViewController {
+            return getCurrentViewController(from: visibleVC)
+        }
+
+        if let presentedVC = rootVC.presentedViewController {
+            return getCurrentViewController(from: presentedVC)
+        }
+
+        return rootVC
+    }
+
+    private func restoreLastState(identifier: String, params: [String: Any]?, navigationController: UINavigationController) {
+        let viewController = createViewController(with: identifier, params: params)
+
+        if let viewController {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { // 초기 뷰컨트롤러 로드할 시간을 줄 수 있도록 지연 시간을 추가
+                navigationController.pushViewController(viewController, animated: false)
+            }
+        }
+    }
+
+    private func createViewController(with identifier: String, params: [String: Any]?) -> UIViewController? {
+        switch identifier {
+        case "MainVC":
+            if let navController = window?.rootViewController as? UINavigationController,
+               let mainVC = navController.viewControllers.first as? MainViewController {
+                DispatchQueue.main.async {
+                    mainVC.restoreState(with: params)
+                }
+            }
+            return nil
+        case "CalculatorVC":
+            let viewModel = CalculatorViewModel()
+            let viewController = CalculatorViewController(viewModel: viewModel)
+            viewController.restoreState(with: params)
+
+            return viewController
+        default:
+            return nil
+        }
+    }
 }
 

--- a/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/ExchangeRateCalculation.xcdatamodeld/ExchangeRateCalculation.xcdatamodel/contents
+++ b/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/ExchangeRateCalculation.xcdatamodeld/ExchangeRateCalculation.xcdatamodel/contents
@@ -10,4 +10,9 @@
     <entity name="FavoriteCurrency" representedClassName="FavoriteCurrency" syncable="YES" codeGenerationType="class">
         <attribute name="currencyCode" optional="YES" attributeType="String"/>
     </entity>
+    <entity name="LastPageEntity" representedClassName="LastPageEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="paramsData" optional="YES" attributeType="Binary"/>
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
 </model>

--- a/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Presentation/CurrencyConverter/CalculatorView.swift
+++ b/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Presentation/CurrencyConverter/CalculatorView.swift
@@ -29,7 +29,7 @@ final class CalculatorView: UIView {
     private let countryLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16)
-        label.textColor = .gray
+        label.textColor = .systemGray
         label.text = "임시국가명"
 
         return label

--- a/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Presentation/CurrencyConverter/CalculatorViewController.swift
+++ b/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Presentation/CurrencyConverter/CalculatorViewController.swift
@@ -1,6 +1,8 @@
 import UIKit
 
-final class CalculatorViewController: UIViewController {
+final class CalculatorViewController: UIViewController, StateManageable {
+    var identifier: String = "CalculatorVC"
+
     private let calculatorView = CalculatorView()
     private let viewModel: CalculatorViewModelProtocol
 
@@ -28,6 +30,40 @@ final class CalculatorViewController: UIViewController {
         calculatorView.configure(with: with)
     }
 
+    func getStateParams() -> [String : Any]? {
+        var params: [String: Any] = [:]
+
+        if let currencyInfo = viewModel.currencyInfo {
+            params["currencyCode"] = currencyInfo.code
+            params["currencyCountry"] = currencyInfo.country
+            params["currencyRate"] = currencyInfo.rate
+            params["currencyTrend"] = currencyInfo.trendString
+            params["currencyUpdatedDate"] = currencyInfo.updatedDate
+        }
+
+        return params
+    }
+
+    func restoreState(with params: [String : Any]?) {
+        guard let params else { return }
+
+        if let code = params["currencyCode"] as? String,
+           let country = params["currencyCountry"] as? String,
+           let rate = params["currencyRate"] as? Double,
+           let trend = params["currencyTrend"] as? String,
+           let updatedDate = params["currencyUpdatedDate"] as? Date {
+            let currencyInfo = CurrencyInfo(
+                code: code,
+                country: country,
+                rate: rate,
+                trendString: trend,
+                updatedDate: updatedDate
+            )
+
+            viewModel.setCurrencyInfo(to: currencyInfo)
+            calculatorView.configure(with: currencyInfo)
+        }
+    }
 }
 
 extension CalculatorViewController: CalculatorViewDelegate {

--- a/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Presentation/Main/ExchangeRateCell.swift
+++ b/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Presentation/Main/ExchangeRateCell.swift
@@ -28,7 +28,7 @@ final class ExchangeRateCell: UITableViewCell {
     private let exchangeRateLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16)
-        label.textColor = .gray
+        label.textColor = .systemGray
         label.textAlignment = .right
 
         return label

--- a/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Presentation/Main/MainView.swift
+++ b/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Presentation/Main/MainView.swift
@@ -44,13 +44,22 @@ final class MainView: UIView {
     }
 
     func reloadTableView() {
-        tableView.reloadData()
+        DispatchQueue.main.async {
+            self.tableView.reloadData()
+        }
     }
 
     func showEmptyView(_ show: Bool) {
         emptyView.isHidden = !show
     }
 
+    func searchText() -> String? {
+        return searchBar.text
+    }
+
+    func setSearchText(to searchText: String) {
+        searchBar.text = searchText
+    }
 }
 
 private extension MainView {

--- a/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Presentation/Main/MainViewModel.swift
+++ b/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Presentation/Main/MainViewModel.swift
@@ -73,6 +73,7 @@ final class MainViewModel: MainViewModelProtocol {
 
     func resetFilteredItems() {
         filteredItems = currencyItems
+        sortItemsWithFavoritesOnTop()
     }
 
 }

--- a/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Utility/Protocol/PageStateProtocol.swift
+++ b/kyuseob/ExchangeRateCalculation/ExchangeRateCalculation/Utility/Protocol/PageStateProtocol.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+protocol StateSavable {
+    var identifier: String { get }
+    func getStateParams() -> [String: Any]?
+}
+
+protocol StateRestorable {
+    func restoreState(with params: [String: Any]?)
+}
+
+typealias StateManageable = StateSavable & StateRestorable // 두 프로토콜을 모두 채택하는 경우


### PR DESCRIPTION
## 구현 사항
### 9레벨
- [x] 다크 모드 대응

### 10레벨
- [x] 사용자가 마지막으로 본 화면 정보를 CoreData에 저장
- [x] 앱을 재시작하면 환율 리스트 화면, 환율 계산기 화면 중 마지막으로 본 화면으로 이동
- [x] AppDelegate 혹은 SceneDelegate 를 이용

## 스크린샷
![마지막 페이지 로드](https://github.com/user-attachments/assets/71c31e10-7211-47c9-b0f9-306d5b800062)


## 참고 사항
디버깅을 반복해 돌려보았는데 크래시가 한번 났는데 원인 파악이 되지 않았고 그 뒤로 크래시가 나지 않아 당장 해결이 어렵습니다.
mainVC에선 검색어를, CalculatorVC에선 통화 정보를 추가 저장 및 복원할 수 있게 구현해두었습니다.
로직 생각을 하고 모르는 부분은 ai에게 물어봐 최대한 이해하면서 받아적고 계속 수정해나가는 식으로 작업했는데 구조가 깔끔하지 않아 보기 좀 힘드실 것 같습니다. 리팩토링을 진행할 필요가 있어보입니다 !

다크 컬러 asset은 후에 리팩토링 시 지정된 코드로 재설정할 예정입니다.